### PR TITLE
Add time validation to appointment DTOs

### DIFF
--- a/src/appointments/dto/create-appointment.dto.ts
+++ b/src/appointments/dto/create-appointment.dto.ts
@@ -3,13 +3,31 @@ import { z } from 'zod';
 import { ZodUtils } from '../../common/utils/zod';
 import { AppointmentZodType } from './base-appointment.dto';
 
-export const CreateAppointmentStaffReqZodType = z.object({
-  patientId: z.number(),
-  doctorId: z.number(),
-  appointmentDate: z.iso.date(),
-  startTime: ZodUtils.TimeZodType,
-  endTime: ZodUtils.TimeZodType,
-});
+export const CreateAppointmentStaffReqZodType = z
+  .object({
+    patientId: z.number(),
+    doctorId: z.number(),
+    appointmentDate: z.iso.date(),
+    startTime: ZodUtils.TimeZodType,
+    endTime: ZodUtils.TimeZodType,
+  })
+  .refine(
+    (data) => {
+      const startTime = data.startTime.split(':');
+      const endTime = data.endTime.split(':');
+      const startHour = parseInt(startTime[0]);
+      const startMinute = parseInt(startTime[1]);
+      const endHour = parseInt(endTime[0]);
+      const endMinute = parseInt(endTime[1]);
+      const start = startHour * 60 + startMinute;
+      const end = endHour * 60 + endMinute;
+      return start < end;
+    },
+    {
+      message: 'Start time must be before end time',
+      path: ['endTime'],
+    },
+  );
 
 export type CreateAppointmentStaffReq = z.infer<
   typeof CreateAppointmentStaffReqZodType
@@ -30,12 +48,30 @@ export type CreateAppointmentStaffRes = z.infer<
   typeof CreateAppointmentStaffResZodType
 >;
 
-export const CreateAppointmentPatientReqZodType = z.object({
-  doctorId: z.number(),
-  appointmentDate: z.iso.date(),
-  startTime: ZodUtils.TimeZodType,
-  endTime: ZodUtils.TimeZodType,
-});
+export const CreateAppointmentPatientReqZodType = z
+  .object({
+    doctorId: z.number(),
+    appointmentDate: z.iso.date(),
+    startTime: ZodUtils.TimeZodType,
+    endTime: ZodUtils.TimeZodType,
+  })
+  .refine(
+    (data) => {
+      const startTime = data.startTime.split(':');
+      const endTime = data.endTime.split(':');
+      const startHour = parseInt(startTime[0]);
+      const startMinute = parseInt(startTime[1]);
+      const endHour = parseInt(endTime[0]);
+      const endMinute = parseInt(endTime[1]);
+      const start = startHour * 60 + startMinute;
+      const end = endHour * 60 + endMinute;
+      return start < end;
+    },
+    {
+      message: 'Start time must be before end time',
+      path: ['endTime'],
+    },
+  );
 
 export type CreateAppointmentPatientReq = z.infer<
   typeof CreateAppointmentPatientReqZodType


### PR DESCRIPTION
Adds a refinement to `CreateAppointmentStaffReqZodType` and `CreateAppointmentPatientReqZodType` to ensure that the `startTime` is always before the `endTime`. This prevents the creation of appointments with invalid time ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved appointment time validation to ensure start times must be before end times when creating appointments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->